### PR TITLE
complementing self-closing tag list

### DIFF
--- a/openTags.json
+++ b/openTags.json
@@ -4,5 +4,15 @@
     "img":true, 
     "br":true, 
     "hr":true, 
-    "link":true
+    "link":true,
+    "area":true,
+    "base":true,
+    "col":true,
+    "embed":true,
+    "input":true,
+    "meta":true,
+    "param":true,
+    "source":true,
+    "track":true,
+    "wbr":true
 }


### PR DESCRIPTION
Complementing self-closing tag list with the new tags:
"area":true,
"base":true,
"col":true,
"embed":true,
"input":true,
"meta":true,
"param":true,
"source":true,
"track":true,
"wbr":true

it solves the issue closes #7 